### PR TITLE
Fix Player.clientUserData type

### DIFF
--- a/src/EmmyLua/core-games-api.def.lua
+++ b/src/EmmyLua/core-games-api.def.lua
@@ -505,7 +505,7 @@ function CoreMeshInstance:IsA(typeName) end
 --- @class GlobalCoreMesh : CoreObject
 CoreMesh = {}
 
---- @class CoreObject
+--- @class CoreObject : Object
 --- @field childAddedEvent Event
 --- @field childRemovedEvent Event
 --- @field descendantAddedEvent Event
@@ -1225,7 +1225,7 @@ function PhysicsObjectInstance:IsA(typeName) end
 --- @class GlobalPhysicsObject : CoreObject
 PhysicsObject = {}
 
---- @class Player
+--- @class Player : CoreObject
 --- @field damagedEvent Event
 --- @field diedEvent Event
 --- @field spawnedEvent Event


### PR DESCRIPTION
# Description

The following code had a type error on `clientUserData` in a client context:
```lua
local localPlayer = Game.GetLocalPlayer()
localPlayer.clientUserData.cool = true
```

But it should be considered a table.

This commit just adds the right inheritance on Player and CoreObject.

* Players are CoreObjects
* CoreObjects are Objects
* Objects have clientUserData


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

- [x] VS Code 1.59, Windows 10, Core v2.3.15.0
- [x] npm run test

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
